### PR TITLE
Code cleanup + Cache file + Small bugfixes

### DIFF
--- a/src/main/java/extension/tools/GPresetExporter.java
+++ b/src/main/java/extension/tools/GPresetExporter.java
@@ -528,7 +528,7 @@ public class GPresetExporter {
                     Integer rotation = fields[2].equals("N") ? null : Integer.parseInt(fields[2]);
                     HPoint location = fields[3].equals("N") || fields[4].equals("N") ? null :
                             new HPoint(Integer.parseInt(fields[3]), Integer.parseInt(fields[4]));
-                    Integer altitude = fields[5].equals("N") ? null : Integer.parseInt(fields[5]);
+                    Integer altitude = fields.length < 6 || fields[5].equals("N") ? null : Integer.parseInt(fields[5]);
 
                     PresetWiredFurniBinding binding = new PresetWiredFurniBinding(bindFurniId, wired.getWiredId(), location, rotation, state, altitude);
                     bindings.add(binding);

--- a/src/main/java/extension/tools/PresetUtils.java
+++ b/src/main/java/extension/tools/PresetUtils.java
@@ -59,8 +59,8 @@ public class PresetUtils {
     public static int lowestFloorPoint(FloorState floor, HPoint start, HPoint end) {
         int lowestPoint = 256;
 
-        for (int x = start.getX(); x < end.getX(); x++) {
-            for (int y = start.getY(); y < end.getY(); y++) {
+        for (int x = start.getX(); x <= end.getX(); x++) {
+            for (int y = start.getY(); y <= end.getY(); y++) {
                 int height = heightFromChar(floor.floorHeight(x, y));
                 if (height < lowestPoint) {
                     lowestPoint = height;

--- a/src/main/java/extension/tools/StackTileSetting.java
+++ b/src/main/java/extension/tools/StackTileSetting.java
@@ -42,7 +42,7 @@ public enum StackTileSetting {
             case "8x8":
                 return XXXL;
         }
-        return null;
+        return Large;
     }
 
     public static StackTileSetting fromClassName(String className) {

--- a/src/main/java/extension/tools/presetconfig/binding/README.md
+++ b/src/main/java/extension/tools/presetconfig/binding/README.md
@@ -1,10 +1,11 @@
-bindings apply to 3 wired boxes;
+bindings apply to 4 wired boxes;
 * WIRED Condition: Furni states match
 * WIRED Negative Condition: Furni states DOESN'T match
 * WIRED Effect: Match furnis to snapshot
+* WIRED Trigger: Furni State Is Changed
 
 
 
-These wired boxes require the particular items in its selection to be in a certain rotation/position/state at time of saving the wired config
+These wired boxes require the particular items in its selection to be in a certain rotation/position/state/altitude at time of saving the wired config
 
 

--- a/src/main/java/extension/tools/presetconfig/wired/PresetWiredAddon.java
+++ b/src/main/java/extension/tools/presetconfig/wired/PresetWiredAddon.java
@@ -1,23 +1,14 @@
 package extension.tools.presetconfig.wired;
 
-import gearth.extensions.IExtension;
-import gearth.protocol.HMessage;
 import gearth.protocol.HPacket;
 import org.json.JSONObject;
-import utils.Utils;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class PresetWiredAddon extends PresetWiredBase {
 
-    private int stuff;
-
     public PresetWiredAddon(HPacket packet) {
         super(packet);
-        pickedFurniSources = Utils.readIntList(packet);
-        pickedUserSources = Utils.readIntList(packet);
     }
 
     public PresetWiredAddon(int wiredId, List<Integer> options, String stringConfig, List<Integer> items, List<Integer> pickedFurniSources, List<Integer> pickedUserSources) {
@@ -34,46 +25,24 @@ public class PresetWiredAddon extends PresetWiredBase {
     }
 
     @Override
+    protected void readTypeSpecific(HPacket packet) {
+    }
+
+    @Override
     protected void appendJsonFields(JSONObject object) {
     }
 
     @Override
-    public void applyWiredConfig(IExtension extension) {
-        HPacket packet = new HPacket(
-                "UpdateAddon",
-                HMessage.Direction.TOSERVER,
-                wiredId
-        );
-        packet.appendInt(options.size());
-        options.forEach(packet::appendInt);
-        packet.appendString(stringConfig);
-        packet.appendInt(items.size());
-        items.forEach(packet::appendInt);
-
-        packet.appendInt(pickedFurniSources.size());
-        pickedFurniSources.forEach(packet::appendInt);
-        packet.appendInt(pickedUserSources.size());
-        pickedUserSources.forEach(packet::appendInt);
-
-        extension.sendToServer(packet);
+    protected String getPacketName() {
+        return "UpdateAddon";
     }
 
     @Override
-    public PresetWiredAddon applyWiredConfig(IExtension extension, Map<Integer, Integer> realFurniIdMap) {
-        if (realFurniIdMap.containsKey(wiredId)) {
-            PresetWiredAddon presetWiredAddon = new PresetWiredAddon(
-                    realFurniIdMap.get(wiredId),
-                    options,
-                    stringConfig,
-                    items.stream().filter(realFurniIdMap::containsKey)
-                            .map(realFurniIdMap::get).collect(Collectors.toList()),
-                    pickedFurniSources,
-                    pickedUserSources
-            );
+    protected void applyTypeSpecificWiredConfig(HPacket packet) {
+    }
 
-            presetWiredAddon.applyWiredConfig(extension);
-            return presetWiredAddon;
-        }
-        return null;
+    @Override
+    public PresetWiredAddon clone() {
+        return new PresetWiredAddon(this);
     }
 }

--- a/src/main/java/extension/tools/presetconfig/wired/PresetWiredSelector.java
+++ b/src/main/java/extension/tools/presetconfig/wired/PresetWiredSelector.java
@@ -1,95 +1,64 @@
 package extension.tools.presetconfig.wired;
 
-import gearth.extensions.IExtension;
-import gearth.protocol.HMessage;
 import gearth.protocol.HPacket;
 import org.json.JSONObject;
-import utils.Utils;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class PresetWiredSelector extends PresetWiredBase {
 
     private boolean filter;
-    private boolean invert;
+    private boolean inverse;
 
     public PresetWiredSelector(HPacket packet) {
         super(packet);
-        filter = packet.readBoolean();
-        invert = packet.readBoolean();
-        pickedFurniSources = Utils.readIntList(packet);
-        pickedUserSources = Utils.readIntList(packet);
     }
 
-    public PresetWiredSelector(int wiredId, List<Integer> options, String stringConfig, List<Integer> items, boolean filter, boolean invert, List<Integer> pickedFurniSources, List<Integer> pickedUserSources) {
-        super(wiredId, options, stringConfig, items, pickedFurniSources, pickedUserSources);
+    public PresetWiredSelector(int wiredId, List<Integer> options, String stringConfig, List<Integer> items, boolean filter, boolean inverse, List<Integer> furniSources, List<Integer> userSources) {
+        super(wiredId, options, stringConfig, items, furniSources, userSources);
         this.filter = filter;
-        this.invert = invert;
+        this.inverse = inverse;
     }
 
     // deep copy constructor
     public PresetWiredSelector(PresetWiredSelector selector) {
         super(selector);
         this.filter = selector.filter;
-        this.invert = selector.invert;
+        this.inverse = selector.inverse;
     }
 
     public PresetWiredSelector(JSONObject object) {
         super(object);
-        this.filter = object.getBoolean("filter");
-        this.invert = object.getBoolean("invert");
+        this.filter = object.optBoolean("filter");
+        this.inverse = object.optBoolean("inverse");
+    }
+
+    @Override
+    protected void readTypeSpecific(HPacket packet) {
+        this.filter = packet.readBoolean();
+        this.inverse = packet.readBoolean();
     }
 
     @Override
     protected void appendJsonFields(JSONObject object) {
         object.put("filter", filter);
-        object.put("invert", invert);
+        object.put("inverse", inverse);
     }
 
     @Override
-    public void applyWiredConfig(IExtension extension) {
-        HPacket packet = new HPacket(
-                "UpdateSelector",
-                HMessage.Direction.TOSERVER,
-                wiredId
-        );
-        packet.appendInt(options.size());
-        options.forEach(packet::appendInt);
-        packet.appendString(stringConfig);
-        packet.appendInt(items.size());
-        items.forEach(packet::appendInt);
+    protected String getPacketName() {
+        return "UpdateSelector";
+    }
 
+    @Override
+    protected void applyTypeSpecificWiredConfig(HPacket packet) {
         packet.appendBoolean(filter);
-        packet.appendBoolean(invert);
-        packet.appendInt(pickedFurniSources.size());
-        pickedFurniSources.forEach(packet::appendInt);
-        packet.appendInt(pickedUserSources.size());
-        pickedUserSources.forEach(packet::appendInt);
-
-        extension.sendToServer(packet);
+        packet.appendBoolean(inverse);
     }
 
     @Override
-    public PresetWiredSelector applyWiredConfig(IExtension extension, Map<Integer, Integer> realFurniIdMap) {
-        if (realFurniIdMap.containsKey(wiredId)) {
-            PresetWiredSelector presetWiredSelector = new PresetWiredSelector(
-                    realFurniIdMap.get(wiredId),
-                    options,
-                    stringConfig,
-                    items.stream().filter(realFurniIdMap::containsKey)
-                            .map(realFurniIdMap::get).collect(Collectors.toList()),
-                    filter,
-                    invert,
-                    pickedFurniSources,
-                    pickedUserSources
-            );
-
-            presetWiredSelector.applyWiredConfig(extension);
-            return presetWiredSelector;
-        }
-        return null;
+    public PresetWiredSelector clone() {
+        return new PresetWiredSelector(this);
     }
 
 }

--- a/src/main/java/extension/tools/presetconfig/wired/PresetWiredTrigger.java
+++ b/src/main/java/extension/tools/presetconfig/wired/PresetWiredTrigger.java
@@ -1,23 +1,14 @@
 package extension.tools.presetconfig.wired;
 
-import gearth.extensions.IExtension;
-import gearth.protocol.HMessage;
 import gearth.protocol.HPacket;
 import org.json.JSONObject;
-import utils.Utils;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class PresetWiredTrigger extends PresetWiredBase {
 
-    private int stuff;
-
     public PresetWiredTrigger(HPacket packet) {
         super(packet);
-        pickedFurniSources = Utils.readIntList(packet);
-        pickedUserSources = Utils.readIntList(packet);
     }
 
     public PresetWiredTrigger(int wiredId, List<Integer> options, String stringConfig, List<Integer> items, List<Integer> pickedFurniSources, List<Integer> pickedUserSources) {
@@ -34,48 +25,25 @@ public class PresetWiredTrigger extends PresetWiredBase {
     }
 
     @Override
+    protected void readTypeSpecific(HPacket packet) {
+    }
+
+    @Override
     protected void appendJsonFields(JSONObject object) {
-        object.put("stuff", stuff);
     }
 
     @Override
-    public void applyWiredConfig(IExtension extension) {
-        HPacket packet = new HPacket(
-                "UpdateTrigger",
-                HMessage.Direction.TOSERVER,
-                wiredId
-        );
-        packet.appendInt(options.size());
-        options.forEach(packet::appendInt);
-        packet.appendString(stringConfig);
-        packet.appendInt(items.size());
-        items.forEach(packet::appendInt);
-
-        packet.appendInt(pickedFurniSources.size());
-        pickedFurniSources.forEach(packet::appendInt);
-        packet.appendInt(pickedUserSources.size());
-        pickedUserSources.forEach(packet::appendInt);
-
-        extension.sendToServer(packet);
+    protected String getPacketName() {
+        return "UpdateTrigger";
     }
 
     @Override
-    public PresetWiredTrigger applyWiredConfig(IExtension extension, Map<Integer, Integer> realFurniIdMap) {
-        if (realFurniIdMap.containsKey(wiredId)) {
-            PresetWiredTrigger presetWiredTrigger = new PresetWiredTrigger(
-                    realFurniIdMap.get(wiredId),
-                    options,
-                    stringConfig,
-                    items.stream().filter(realFurniIdMap::containsKey)
-                            .map(realFurniIdMap::get).collect(Collectors.toList()),
-                    pickedFurniSources,
-                    pickedUserSources
-            );
+    protected void applyTypeSpecificWiredConfig(HPacket packet) {
+    }
 
-            presetWiredTrigger.applyWiredConfig(extension);
-            return presetWiredTrigger;
-        }
-        return null;
+    @Override
+    public PresetWiredTrigger clone() {
+        return new PresetWiredTrigger(this);
     }
 
 }

--- a/src/main/java/extension/tools/presetconfig/wired/PresetWireds.java
+++ b/src/main/java/extension/tools/presetconfig/wired/PresetWireds.java
@@ -6,7 +6,6 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/src/main/java/extension/tools/presetconfig/wired/incoming/RetrievedWired.java
+++ b/src/main/java/extension/tools/presetconfig/wired/incoming/RetrievedWired.java
@@ -1,7 +1,47 @@
 package extension.tools.presetconfig.wired.incoming;
 
+import gearth.protocol.HPacket;
+import utils.Utils;
+
+import java.util.List;
+
 public interface RetrievedWired {
 
     int getTypeId();
+
+    static <T extends RetrievedWired> T fromPacket(HPacket packet, Class<T> cls) {
+        packet.readInteger(); // selection limit
+
+        List<Integer> items = Utils.readIntList(packet);
+
+        int typeId = packet.readInteger(); // typeid
+        int wiredId = packet.readInteger(); // furni id
+
+        String configString = packet.readString();
+        List<Integer> options = Utils.readIntList(packet);
+
+        List<Integer> furniSources = Utils.readIntList(packet);
+        List<Integer> userSources = Utils.readIntList(packet);
+
+        if (cls == RetrievedWiredAddon.class) {
+            return cls.cast(new RetrievedWiredAddon(wiredId, options, configString, items, typeId, furniSources, userSources));
+        } else if (cls == RetrievedWiredTrigger.class) {
+            return cls.cast(new RetrievedWiredTrigger(wiredId, options, configString, items, typeId, furniSources, userSources));
+        } else if (cls == RetrievedWiredEffect.class) {
+            int delay = packet.readInteger();
+            return cls.cast(new RetrievedWiredEffect(wiredId, options, configString, items, delay, typeId, furniSources, userSources));
+        } else if (cls == RetrievedWiredCondition.class) {
+            packet.readInteger();
+            int quantifier = packet.readInteger();
+            return cls.cast(new RetrievedWiredCondition(wiredId, options, configString, items, typeId, quantifier, furniSources, userSources));
+        } else if (cls == RetrievedWiredSelector.class) {
+            packet.readInteger();
+            boolean filter = packet.readBoolean();
+            boolean invert = packet.readBoolean();
+            return cls.cast(new RetrievedWiredSelector(wiredId, options, configString, items, typeId, filter, invert, furniSources, userSources));
+        }
+
+        return null;
+    }
 
 }

--- a/src/main/java/extension/tools/presetconfig/wired/incoming/RetrievedWiredAddon.java
+++ b/src/main/java/extension/tools/presetconfig/wired/incoming/RetrievedWiredAddon.java
@@ -2,9 +2,7 @@ package extension.tools.presetconfig.wired.incoming;
 
 import extension.tools.presetconfig.wired.PresetWiredAddon;
 import gearth.protocol.HPacket;
-import utils.Utils;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class RetrievedWiredAddon extends PresetWiredAddon implements RetrievedWired {
@@ -22,22 +20,6 @@ public class RetrievedWiredAddon extends PresetWiredAddon implements RetrievedWi
     }
 
     public static RetrievedWiredAddon fromPacket(HPacket packet) {
-        packet.readInteger(); // selection limit
-
-
-
-        List<Integer> items = Utils.readIntList(packet);
-
-        int typeId = packet.readInteger(); // typeid
-
-        int wiredId = packet.readInteger(); // furni id
-        String configString = packet.readString();
-
-        List<Integer> options = Utils.readIntList(packet);
-
-        List<Integer> furniSources = Utils.readIntList(packet);
-        List<Integer> userSources = Utils.readIntList(packet);
-
-        return new RetrievedWiredAddon(wiredId, options, configString, items, typeId, furniSources, userSources);
+        return RetrievedWired.fromPacket(packet, RetrievedWiredAddon.class);
     }
 }

--- a/src/main/java/extension/tools/presetconfig/wired/incoming/RetrievedWiredCondition.java
+++ b/src/main/java/extension/tools/presetconfig/wired/incoming/RetrievedWiredCondition.java
@@ -2,9 +2,7 @@ package extension.tools.presetconfig.wired.incoming;
 
 import extension.tools.presetconfig.wired.PresetWiredCondition;
 import gearth.protocol.HPacket;
-import utils.Utils;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class RetrievedWiredCondition extends PresetWiredCondition implements RetrievedWired {
@@ -22,26 +20,6 @@ public class RetrievedWiredCondition extends PresetWiredCondition implements Ret
     }
 
     public static RetrievedWiredCondition fromPacket(HPacket packet) {
-        packet.readInteger(); // selection limit
-
-        List<Integer> items = Utils.readIntList(packet);
-
-        int typeId = packet.readInteger(); // typeid
-
-
-        int wiredId = packet.readInteger(); // furni id
-        String configString = packet.readString();
-
-        List<Integer> options = Utils.readIntList(packet);
-
-        List<Integer> furniSources = Utils.readIntList(packet);
-        List<Integer> userSources = Utils.readIntList(packet);
-
-        packet.readInteger();
-        int quantifier = packet.readInteger();
-
-
-        // more irrelevant stuff here
-        return new RetrievedWiredCondition(wiredId, options, configString, items, typeId, quantifier, furniSources, userSources);
+        return RetrievedWired.fromPacket(packet, RetrievedWiredCondition.class);
     }
 }

--- a/src/main/java/extension/tools/presetconfig/wired/incoming/RetrievedWiredEffect.java
+++ b/src/main/java/extension/tools/presetconfig/wired/incoming/RetrievedWiredEffect.java
@@ -2,9 +2,7 @@ package extension.tools.presetconfig.wired.incoming;
 
 import extension.tools.presetconfig.wired.PresetWiredEffect;
 import gearth.protocol.HPacket;
-import utils.Utils;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class RetrievedWiredEffect extends PresetWiredEffect implements RetrievedWired {
@@ -22,23 +20,6 @@ public class RetrievedWiredEffect extends PresetWiredEffect implements Retrieved
     }
 
     public static RetrievedWiredEffect fromPacket(HPacket packet) {
-        packet.readInteger(); // selection limit
-
-        List<Integer> items = Utils.readIntList(packet);
-
-        int typeId = packet.readInteger(); // typeid
-        int wiredId = packet.readInteger(); // furni id
-
-        String configString = packet.readString();
-        List<Integer> options = Utils.readIntList(packet);
-
-        List<Integer> furniSources = Utils.readIntList(packet);
-        List<Integer> userSources = Utils.readIntList(packet);
-
-        packet.readInteger(); // wired code
-        int delay = packet.readInteger(); // delay
-
-        // more irrelevant stuff here
-        return new RetrievedWiredEffect(wiredId, options, configString, items, delay, typeId, furniSources, userSources);
+        return RetrievedWired.fromPacket(packet, RetrievedWiredEffect.class);
     }
 }

--- a/src/main/java/extension/tools/presetconfig/wired/incoming/RetrievedWiredSelector.java
+++ b/src/main/java/extension/tools/presetconfig/wired/incoming/RetrievedWiredSelector.java
@@ -2,7 +2,6 @@ package extension.tools.presetconfig.wired.incoming;
 
 import extension.tools.presetconfig.wired.PresetWiredSelector;
 import gearth.protocol.HPacket;
-import utils.Utils;
 
 import java.util.List;
 
@@ -21,26 +20,6 @@ public class RetrievedWiredSelector extends PresetWiredSelector implements Retri
     }
 
     public static RetrievedWiredSelector fromPacket(HPacket packet) {
-        packet.readInteger(); // selection limit
-
-        List<Integer> items = Utils.readIntList(packet);
-
-        int typeId = packet.readInteger(); // typeid
-
-
-        int wiredId = packet.readInteger(); // furni id
-        String configString = packet.readString();
-
-        List<Integer> options = Utils.readIntList(packet);
-
-        List<Integer> furniSources = Utils.readIntList(packet);
-        List<Integer> userSources = Utils.readIntList(packet);
-
-        packet.readInteger();
-        boolean filter = packet.readBoolean();
-        boolean invert = packet.readBoolean();
-
-        // more irrelevant stuff here
-        return new RetrievedWiredSelector(wiredId, options, configString, items, typeId, filter, invert, furniSources, userSources);
+        return RetrievedWired.fromPacket(packet, RetrievedWiredSelector.class);
     }
 }

--- a/src/main/java/extension/tools/presetconfig/wired/incoming/RetrievedWiredTrigger.java
+++ b/src/main/java/extension/tools/presetconfig/wired/incoming/RetrievedWiredTrigger.java
@@ -2,9 +2,7 @@ package extension.tools.presetconfig.wired.incoming;
 
 import extension.tools.presetconfig.wired.PresetWiredTrigger;
 import gearth.protocol.HPacket;
-import utils.Utils;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class RetrievedWiredTrigger extends PresetWiredTrigger implements RetrievedWired {
@@ -22,22 +20,6 @@ public class RetrievedWiredTrigger extends PresetWiredTrigger implements Retriev
     }
 
     public static RetrievedWiredTrigger fromPacket(HPacket packet) {
-        packet.readInteger(); // selection limit
-
-        List<Integer> items = Utils.readIntList(packet);
-
-        int typeId = packet.readInteger(); // typeid
-
-
-        int wiredId = packet.readInteger(); // furni id
-        String configString = packet.readString();
-
-        List<Integer> options = Utils.readIntList(packet);
-
-        List<Integer> furniSources = Utils.readIntList(packet);
-        List<Integer> userSources = Utils.readIntList(packet);
-
-        // more irrelevant stuff here
-        return new RetrievedWiredTrigger(wiredId, options, configString, items, typeId, furniSources, userSources);
+        return RetrievedWired.fromPacket(packet, RetrievedWiredTrigger.class);
     }
 }

--- a/src/main/java/extension/ui/gpresets.fxml
+++ b/src/main/java/extension/ui/gpresets.fxml
@@ -61,23 +61,24 @@
                   <RadioButton layoutX="262.0" layoutY="14.0" mnemonicParsing="false" text="6x6" toggleGroup="$stacktile_tgl" />
                   <RadioButton layoutX="314.0" layoutY="14.0" mnemonicParsing="false" text="8x8" toggleGroup="$stacktile_tgl" />
                   <Label layoutX="14.0" layoutY="45.0" text="Item source:" />
-                  <RadioButton fx:id="onlyInvCbx" layoutX="93.0" layoutY="45.0" mnemonicParsing="false" selected="true" text="Only Inventory">
+                  <RadioButton fx:id="onlyInvCbx" layoutX="93.0" layoutY="45.0" mnemonicParsing="false" selected="true" text="Only Inventory" userData="ONLY_INVENTORY">
                      <toggleGroup>
                         <ToggleGroup fx:id="item_src_tgl" />
                      </toggleGroup>
                   </RadioButton>
-                  <RadioButton fx:id="preferInvCbx" layoutX="203.0" layoutY="45.0" mnemonicParsing="false" text="Prefer Inventory" toggleGroup="$item_src_tgl" />
-                  <RadioButton fx:id="preferBcCbx" layoutX="320.0" layoutY="45.0" mnemonicParsing="false" text="Prefer BC" toggleGroup="$item_src_tgl" />
-                  <RadioButton fx:id="onlyBcCbx" layoutX="405.0" layoutY="45.0" mnemonicParsing="false" text="Only BC" toggleGroup="$item_src_tgl" />
+                  <RadioButton fx:id="preferInvCbx" layoutX="203.0" layoutY="45.0" mnemonicParsing="false" text="Prefer Inventory" toggleGroup="$item_src_tgl" userData="PREFER_INVENTORY" />
+                  <RadioButton fx:id="preferBcCbx" layoutX="320.0" layoutY="45.0" mnemonicParsing="false" text="Prefer BC" toggleGroup="$item_src_tgl" userData="PREFER_BC" />
+                  <RadioButton fx:id="onlyBcCbx" layoutX="405.0" layoutY="45.0" mnemonicParsing="false" text="Only BC" toggleGroup="$item_src_tgl" userData="ONLY_BC" />
                   <Button layoutX="13.0" layoutY="223.0" mnemonicParsing="false" onAction="#openPresetsFolderClick" prefHeight="25.0" prefWidth="157.0" text="Open Presets Folder" />
                   <Button fx:id="currentPresetBtn" layoutX="187.0" layoutY="223.0" mnemonicParsing="false" onAction="#openCurrentPresetClick" prefHeight="25.0" prefWidth="222.0" text="Open Selected Preset In Editor" />
-                  <Button layoutX="543.0" layoutY="223.0" mnemonicParsing="false" onAction="#reloadPresetsClick" prefHeight="25.0" prefWidth="131.0" text="Reload Presets" />
+                  <Button layoutX="541.0" layoutY="188.0" mnemonicParsing="false" onAction="#reloadPresetsClick" prefHeight="25.0" prefWidth="131.0" text="Reload Presets" />
                   <CheckBox fx:id="allowIncompleteBuildsCbx" layoutX="14.0" layoutY="187.0" mnemonicParsing="false" prefHeight="32.0" prefWidth="205.0" text="Allow building without all furni" />
                   <RadioButton layoutX="106.0" layoutY="14.0" mnemonicParsing="false" text="1x1" toggleGroup="$stacktile_tgl" />
                   <CheckBox fx:id="noExportWiredCbx" layoutX="14.0" layoutY="167.0" mnemonicParsing="false" text="Do not export wired" />
                   <Slider fx:id="ratelimiter" layoutX="82.0" layoutY="80.0" prefHeight="14.0" prefWidth="219.0" value="22.0" />
                   <Label layoutX="13.0" layoutY="78.0" text="Ratelimit:" />
-                  <CheckBox fx:id="onTopCbx" layoutX="576.0" layoutY="195.0" mnemonicParsing="false" onAction="#alwaysOnTopClick" text="Always on top" />
+                  <CheckBox fx:id="onTopCbx" layoutX="576.0" layoutY="159.0" mnemonicParsing="false" onAction="#alwaysOnTopClick" text="Always on top" />
+                  <Button layoutX="541.0" layoutY="223.0" mnemonicParsing="false" onAction="#clearBCClick" prefHeight="25.0" prefWidth="131.0" text="Clear BC Cache" />
                </children></AnchorPane>
       </content>
     </Tab>

--- a/src/main/java/game/BCCatalog.java
+++ b/src/main/java/game/BCCatalog.java
@@ -256,4 +256,16 @@ public class BCCatalog {
         }
         return false;
     }
+
+    public void clearCache() throws URISyntaxException {
+        String path = (new File(GPresets.class.getProtectionDomain().getCodeSource().getLocation().toURI()))
+                .getParentFile().toString();
+        File root = new File(Paths.get(path, "catalog").toString());
+        if (root.exists() && root.listFiles() != null) {
+            for (File file : root.listFiles()) {
+                System.out.println(file);
+                file.delete();
+            }
+        }
+    }
 }

--- a/src/main/java/game/FloorState.java
+++ b/src/main/java/game/FloorState.java
@@ -409,7 +409,7 @@ public class FloorState {
 
     public double getTileHeight(int x, int y) {
         synchronized (lock) {
-            return ((double)heightmap[x][y]) / 256;
+            return ((double)(heightmap[x][y] & 16383)) / 256;
         }
     }
 

--- a/src/main/java/game/FloorState.java
+++ b/src/main/java/game/FloorState.java
@@ -161,14 +161,7 @@ public class FloorState {
                 }
             }
 
-            for (HFloorItem item : floorItems) {
-                furnimap.get(item.getTile().getX()).get(item.getTile().getY()).put(item.getId(), item);
-                furniIdToItem.put(item.getId(), item);
-                if (!typeIdToItems.containsKey(item.getTypeId())) {
-                    typeIdToItems.put(item.getTypeId(), new HashSet<>());
-                }
-                typeIdToItems.get(item.getTypeId()).add(item);
-            }
+            Arrays.stream(floorItems).forEach(this::addObject);
         }
 
         onFurnisChange.call();
@@ -207,14 +200,20 @@ public class FloorState {
             }
             item.setOwnerName(ownerName);
 
-            furnimap.get(item.getTile().getX()).get(item.getTile().getY()).put(item.getId(), item);
-            furniIdToItem.put(item.getId(), item);
-            if (!typeIdToItems.containsKey(item.getTypeId())) {
-                typeIdToItems.put(item.getTypeId(), new HashSet<>());
-            }
-            typeIdToItems.get(item.getTypeId()).add(item);
+            addObject(item);
         }
     }
+
+    private void addObject(HFloorItem item) {
+        furnimap.get(item.getTile().getX()).get(item.getTile().getY()).put(item.getId(), item);
+        furniIdToItem.put(item.getId(), item);
+        if (!typeIdToItems.containsKey(item.getTypeId())) {
+            typeIdToItems.put(item.getTypeId(), new HashSet<>());
+        }
+        typeIdToItems.get(item.getTypeId()).add(item);
+
+    }
+
     private void onObjectUpdate(HMessage hMessage) {
         if (inRoom()) {
             HFloorItem newItem = new HFloorItem(hMessage.getPacket());
@@ -230,28 +229,24 @@ public class FloorState {
             addObject(hMessage.getPacket(), owner);
         }
     }
+
     private void onSlide(HMessage hMessage) {
         if (inRoom()) {
             HPacket packet = hMessage.getPacket();
-            int oldx = packet.readInteger();
-            int oldy = packet.readInteger();
-            int newx = packet.readInteger();
-            int newy = packet.readInteger();
+            int oldX = packet.readInteger();
+            int oldY = packet.readInteger();
+            int newX = packet.readInteger();
+            int newY = packet.readInteger();
 
             int amount = packet.readInteger();
 
             synchronized (lock) {
                 for (int i = 0; i < amount; i++) {
                     int furniId = packet.readInteger();
-                    String oldz = packet.readString();
-                    String newz = packet.readString();
+                    String oldZ = packet.readString();
+                    String newZ = packet.readString();
 
-                    HFloorItem item = furniIdToItem.get(furniId);
-                    if (item != null) {
-                        furnimap.get(item.getTile().getX()).get(item.getTile().getY()).remove(item.getId());
-                        item.setTile(new HPoint(newx, newy, Double.parseDouble(newz)));
-                        furnimap.get(newx).get(newy).put(item.getId(), item);
-                    }
+                    updateFurniPosition(furniId, newX, newY, newZ);
                 }
             }
 
@@ -273,13 +268,17 @@ public class FloorState {
 
                 int furniId = packet.readInteger();
 
-                HFloorItem item = furniIdToItem.get(furniId);
-                if (item != null) {
-                    furnimap.get(item.getTile().getX()).get(item.getTile().getY()).remove(item.getId());
-                    item.setTile(new HPoint(newX, newY, Double.parseDouble(newZ)));
-                    furnimap.get(newX).get(newY).put(item.getId(), item);
-                }
+                updateFurniPosition(furniId, newX, newY, newZ);
             }
+        }
+    }
+
+    private void updateFurniPosition(int furniId, int newX, int newY, String newZ) {
+        HFloorItem item = furniIdToItem.get(furniId);
+        if (item != null) {
+            furnimap.get(item.getTile().getX()).get(item.getTile().getY()).remove(item.getId());
+            item.setTile(new HPoint(newX, newY, Double.parseDouble(newZ)));
+            furnimap.get(newX).get(newY).put(item.getId(), item);
         }
     }
 
@@ -317,12 +316,7 @@ public class FloorState {
                         int animationTime = packet.readInteger();
                         int direction = packet.readInteger();
 
-                        HFloorItem item = furniIdToItem.get(furniId);
-                        if (item != null) {
-                            furnimap.get(item.getTile().getX()).get(item.getTile().getY()).remove(item.getId());
-                            item.setTile(new HPoint(newX, newY, Double.parseDouble(newZ)));
-                            furnimap.get(newX).get(newY).put(item.getId(), item);
-                        }
+                        updateFurniPosition(furniId, newX, newY, newZ);
                     }
                     else { // wall item
                         packet.readInteger();


### PR DESCRIPTION
Changes:
- Cleaned up duplicate code in Wired classes
- Cleaned up duplicate code in FloorState.java
- Added a cache file for the Settings tab
- Added a `Clear BC Cache` button
- Fixed bug in [maybeRetrieveBindings in GPresetExporter](https://github.com/sirjonasxx/G-Presets/commit/2375aaa491ae8bc1256a9fb70e09dfad009e31f6)
  - Some snapshot wireds which were last saved before altitude got added as an option caused it to crash
- Fixed bug in [lowestFloorPoint in PresetUtils.java](https://github.com/sirjonasxx/G-Presets/commit/65c116d4e05d1b0ff26e213831cb7bdd90642ac4#diff-de2dbc0004db03508a60feba42e354726a2c9c872dd17ff4b73e3b06d8e140bbR62-R63)
  - It was ignoring tiles on the outer edges of the area where items were actually present
- Fixed bug in [getTileHeight in FloorState.java](https://github.com/sirjonasxx/G-Presets/commit/ab7f44535fd020bdc107f87aa9185d9988a0b33d)
  - The function isn't used tho