### PR TITLE
Bugfix on invalid character for preset name (filename)

### DIFF
--- a/src/main/java/extension/tools/GPresetExporter.java
+++ b/src/main/java/extension/tools/GPresetExporter.java
@@ -152,19 +152,10 @@ public class GPresetExporter {
                 }
             } else if (state == PresetExportState.AWAITING_NAME) {
                 hMessage.setBlocked(true);
-
-                StringBuilder invalidChars = new StringBuilder();
-                for (char c : Utils.getInvalidOsFileCharacters()) {
-                    if (text.indexOf(c) != -1) {
-                        invalidChars.append(c);
-                    }
-                }
-
-                if (invalidChars.length() > 0) {
-                    extension.sendVisualChatInfo(String.format("invalid characters '%s' for the preset name. Waiting for a valid name...", invalidChars.toString()));
+                if (!text.matches("[^<>:\"\\/\\\\|?*]*")) {
+                    extension.sendVisualChatInfo("Invalid characters in name, don't use the following characters: < > : / \\ | ? *");
                     return;
                 }
-
                 int x1 = rectCorner1.getX();
                 int y1 = rectCorner1.getY();
                 int x2 = rectCorner2.getX();

--- a/src/main/java/extension/tools/GPresetExporter.java
+++ b/src/main/java/extension/tools/GPresetExporter.java
@@ -153,7 +153,7 @@ public class GPresetExporter {
             } else if (state == PresetExportState.AWAITING_NAME) {
                 hMessage.setBlocked(true);
                 if (!text.matches("[^<>:\"\\/\\\\|?*]*")) {
-                    extension.sendVisualChatInfo("Invalid characters in name, don't use the following characters: < > : / \\ | ? *");
+                    extension.sendVisualChatInfo("Invalid characters in name, don't use the following characters: &lt; &gt; : / \\ | ? *");
                     return;
                 }
                 int x1 = rectCorner1.getX();

--- a/src/main/java/extension/tools/GPresetExporter.java
+++ b/src/main/java/extension/tools/GPresetExporter.java
@@ -152,6 +152,19 @@ public class GPresetExporter {
                 }
             } else if (state == PresetExportState.AWAITING_NAME) {
                 hMessage.setBlocked(true);
+
+                StringBuilder invalidChars = new StringBuilder();
+                for (char c : Utils.getInvalidOsFileCharacters()) {
+                    if (text.indexOf(c) != -1) {
+                        invalidChars.append(c);
+                    }
+                }
+
+                if (invalidChars.length() > 0) {
+                    extension.sendVisualChatInfo(String.format("invalid characters '%s' for the preset name. Waiting for a valid name...", invalidChars.toString()));
+                    return;
+                }
+
                 int x1 = rectCorner1.getX();
                 int y1 = rectCorner1.getY();
                 int x2 = rectCorner2.getX();

--- a/src/main/java/utils/Utils.java
+++ b/src/main/java/utils/Utils.java
@@ -23,6 +23,10 @@ public class Utils {
         Utils.extraSleepTime = extraSleepTime;
     }
 
+    public static char[] getInvalidOsFileCharacters() {
+        return new char[]{'<', '>', ':', '"', '/', '\\', '|', '?', '*'};
+    }
+
     public static List<Integer> readIntList(HPacket packet) {
         int size = packet.readInteger();
         List<Integer> intList = new ArrayList<>();

--- a/src/main/java/utils/Utils.java
+++ b/src/main/java/utils/Utils.java
@@ -23,10 +23,6 @@ public class Utils {
         Utils.extraSleepTime = extraSleepTime;
     }
 
-    public static char[] getInvalidOsFileCharacters() {
-        return new char[]{'<', '>', ':', '"', '/', '\\', '|', '?', '*'};
-    }
-
     public static List<Integer> readIntList(HPacket packet) {
         int size = packet.readInteger();
         List<Integer> intList = new ArrayList<>();


### PR DESCRIPTION
Before, when giving invalid filename like "test/test", it was giving success message about Exported into "test/test" instead of an error message.

So at the end :
* It is losing the selection we did
* The message show like it has been a success export
* User might wrongfully pickall or do any irreversible action thinking that everything went well.

This PR shows what character is not supported (by the OS as a filename). And properly wait for a valid filename instead.